### PR TITLE
Fixed incorrect version for SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the following dependency to your project's `pom.xml`.
     <dependency>
       <groupId>io.nats</groupId>
       <artifactId>jnats</artifactId>
-      <version>0.4-SNAPSHOT</version>
+      <version>0.4.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 ```


### PR DESCRIPTION
I created a project to use jnats as a dependency and observed this error when attempting to build:

org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact io.nats:jnats:jar:0.4-SNAPSHOT in sonatype-snapshots (https://oss.sonatype.org/content/repositories/snapshots)

Upon digging into the issue, I discovered that it was a simple typo in the version that was published to the README.md file. After changing the version 0.4-SNAPSHOT to 0.4.0-SNAPSHOT, my project build completed successfully.