### PR TITLE
add maven bundle plugin to provide OSGI compliant jnats bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <groupId>io.nats</groupId>
     <artifactId>jnats</artifactId>
     <version>0.5.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <name>jnats</name>
     <description>Java client library for NATS Messaging System</description>
@@ -60,6 +60,13 @@
 
     <build>
         <plugins>
+            <plugin>
+                <!-- This plugin takes care of packaging the artifact as an OSGi Bundle -->
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <version>2.4.0</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Dear JNATS community,

here's some diff to provide OSGI compliant jnats bundle. Currently with the provided configuration - ie: nothing - the following manifest is generated : 

```
Manifest-Version: 1.0
Bnd-LastModified: 1462300236144
Build-Jdk: 1.8.0_72-internal
Built-By: mffrench
Bundle-Description: Java client library for NATS Messaging System
Bundle-DocURL: http://nats.io
Bundle-License: http://www.opensource.org/licenses/mit-license.php
Bundle-ManifestVersion: 2
Bundle-Name: jnats
Bundle-SymbolicName: io.nats.jnats
Bundle-Vendor: Apcera, Inc.
Bundle-Version: 0.5.0.SNAPSHOT
Created-By: Apache Maven Bundle Plugin
Export-Package: io.nats.client;uses:="javax.net.ssl";version="0.5.0.SNAP
 SHOT"
Import-Package: javax.net,javax.net.ssl,org.slf4j;version="[1.7,2)"
Tool: Bnd-2.1.0.20130426-122213
```

Let me know if you see any problems with this minimal change.

Thank you !