### PR TITLE
Override unsubscribe in AsyncSubscriptionImpl

### DIFF
--- a/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
+++ b/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
@@ -140,4 +140,10 @@ class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscriptio
         super.close();
         disable();
     }
+    
+    @Override
+    public void unsubscribe() throws IOException {
+        super.unsubscribe();
+        disable();
+    }
 }


### PR DESCRIPTION
Currently, AsyncSubscriptionImpl leaks the msgfeeder thread on
unsubscribe because Channel.get() is never unblocked. This
overrides unsubscribe so that the thread properly terminates.
I believe this resolves issue #26.

FYI @stevenosborne-wf