### PR TITLE
make ConnectionImpl public

### DIFF
--- a/src/main/java/io/nats/client/ConnectionImpl.java
+++ b/src/main/java/io/nats/client/ConnectionImpl.java
@@ -57,7 +57,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-class ConnectionImpl implements Connection {
+public class ConnectionImpl implements Connection {
     final Logger logger = LoggerFactory.getLogger(ConnectionImpl.class);
 
     String version = null;


### PR DESCRIPTION
when used from clojure a package-protected `ConnectionImpl` triggers this bug -

http://dev.clojure.org/jira/browse/CLJ-1243

which is perhaps a symptom of this underlying issue with reflection -

http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4283544

the effect is that trying to call `ConnectionImpl` methods overridden from `AbstractConnection`, such as `subscribeAsync`, throws an exception

```
IllegalArgumentException Can't call public method of non-public class: public io.nats.client.AsyncSubscription io.nats.client.ConnectionImpl.subscribeAsync(java.lang.String)  clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:88)
```

so this PR makes the `ConnectionImpl` class public, which solves the issue, and i can't see a downside