### PR TITLE
Added skip_cleanup to .travis.yml deploy section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ after_success:
 deploy:
   -
     provider: script
+    skip_cleanup: true
     script: .travis/deploy.sh
     on:
       repo: nats-io/jnats
@@ -22,6 +23,7 @@ deploy:
       jdk: oraclejdk8
   -
     provider: script
+    skip_cleanup: true
     script: .travis/deploy.sh
     on:
       repo: nats-io/jnats


### PR DESCRIPTION
Gets rid of 'git stash' errors that cause deployment to fail.